### PR TITLE
Ignore unused lambda warning

### DIFF
--- a/DebugIR.cpp
+++ b/DebugIR.cpp
@@ -320,6 +320,7 @@ private:
     const Function *F = B->getParent();
 
     auto returnFallback = [this, I]() {
+      (void)I;
       LLVM_DEBUG(dbgs() << "WARNING: Using fallback lexical block file scope "
                         << LexicalBlockFileNode << " as scope for instruction "
                         << I << "\n");


### PR DESCRIPTION
Trying to compile this on nix 21.05 caused this error:

```
[ 33%] Building CXX object CMakeFiles/debugir.dir/DebugIR.cpp.o
/tmp/nix-build-debugir.drv-0/source/DebugIR.cpp:322:34: error: lambda capture 'I' is not used [-Werror,-Wunused-lambda-capture]
    auto returnFallback = [this, I]() {
                               ~~^
1 error generated.
make[2]: *** [CMakeFiles/debugir.dir/build.make:82: CMakeFiles/debugir.dir/DebugIR.cpp.o] Error 1
```

Here are the files I used:

```
$ cat debugir/shell.nix
let
  sources = import ./nix/sources.nix { };
  nixpkgs = import sources.nixpkgs { };
in with nixpkgs;
mkShell { buildInputs = [ cmake libxml2 llvmPackages_12.llvm.dev ]; }
```

```
$ cat debugir/nix/sources.json
{
    "nixpkgs": {
        "branch": "release-21.05",
        "description": "Nix Packages collection",
        "homepage": "",
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "5f244caea76105b63d826911b2a1563d33ff1cdc",
        "sha256": "1xlgynfw9svy7nvh9nkxsxdzncv9hg99gbvbwv3gmrhmzc3sar75",
        "type": "tarball",
        "url": "https://github.com/NixOS/nixpkgs/archive/5f244caea76105b63d826911b2a1563d33ff1cdc.tar.gz",
        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
    }
}
```

After making this change, the project compiles fine!