### PR TITLE
Use LLVM shared lib instead of individual static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,6 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 find_package(LLVM 18.1 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-# Find the libraries that correspond to the LLVM components we use
-llvm_map_components_to_libnames(llvm_libs support core irreader transformutils Passes)
 
 add_executable(debugir
   DebugIR.cpp
@@ -47,4 +45,4 @@ separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 target_compile_definitions(debugir PUBLIC ${LLVM_DEFINITIONS_LIST})
 target_include_directories(debugir PUBLIC ${PROJECT_SOURCE_DIR})
 target_include_directories(debugir PUBLIC ${LLVM_INCLUDE_DIRS})
-target_link_libraries (debugir PUBLIC ${llvm_libs})
+target_link_libraries (debugir PUBLIC LLVM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5.1)
 
 project(DebugIR LANGUAGES C CXX)
 
+option(LINK_LLVM_SHARED "Control whether debugir links to a shared LLVM library, or individual static components" ON)
+
 # export compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # C++ standard
@@ -20,6 +22,12 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 find_package(LLVM 18.1 REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+if(LINK_LLVM_SHARED)
+  set(llvm_libs LLVM)
+else()
+  # Find the libraries that correspond to the LLVM components we use
+  llvm_map_components_to_libnames(llvm_libs support core irreader transformutils Passes)
+endif()
 
 add_executable(debugir
   DebugIR.cpp
@@ -45,4 +53,4 @@ separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 target_compile_definitions(debugir PUBLIC ${LLVM_DEFINITIONS_LIST})
 target_include_directories(debugir PUBLIC ${PROJECT_SOURCE_DIR})
 target_include_directories(debugir PUBLIC ${LLVM_INCLUDE_DIRS})
-target_link_libraries (debugir PUBLIC LLVM)
+target_link_libraries (debugir PUBLIC ${llvm_libs})

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ This tool requires LLVM-18 to be installed.
 If you have LLVM installed in a non-standard path, you may provide the
 additional `CMake` argument `-DLLVM_DIR=/path/to/llvm`.
 
+If you would like to link debugir to the relevant static LLVM components, use
+```
+-DLINK_LLVM_SHARED=OFF
+```
+during the cmake command. 
+
 ### Run
 You should now have an executable file `debugir` in the build directory.
 


### PR DESCRIPTION
I'm working on a follow-up PR that allows debugir to be used as a library in other LLVM projects. Linking in specific LLVM components statically causes "command line option registered more than once" errors if the parent project also links in these components. 

A common way to avoid this is to just dynamically link to the libLLVM.so library. 