### PR TITLE
Replace DICompileUnit in DISubprogram scopes

### DIFF
--- a/DebugIR.cpp
+++ b/DebugIR.cpp
@@ -292,6 +292,10 @@ private:
     NamedMDNode *NMD = M.getOrInsertNamedMetadata("llvm.dbg.cu");
     NMD->clearOperands();
     NMD->addOperand(CU);
+
+    for (DISubprogram *S : Finder.subprograms()) {
+      S->replaceUnit(CU);
+    }
   }
 
   DIScope *getBlockScope(DIScope *ParentScope, const BasicBlock *B) {


### PR DESCRIPTION
Without this fix the `Module` can fail to verify with "dicompileunit not listed in llvm.dbg.cu", since the old `DICompileUnit` will be retained by the dangling reference.