### PR TITLE
Use `llvm.dbg.value` instead of `llvm.dbg.declare` for SSA values

### DIFF
--- a/DebugIR.cpp
+++ b/DebugIR.cpp
@@ -252,6 +252,9 @@ public:
       return;
     }
 
+    if (isa<PHINode>(I))
+      Scope = Scope->getSubprogram(); // See https://github.com/llvm/llvm-project/issues/118883
+
     DebugLoc NewLoc =
         DebugLoc(DILocation::get(M.getContext(), Line, Col, Scope, InlinedAt));
     addDebugLocation(I, NewLoc);

--- a/DebugIR.cpp
+++ b/DebugIR.cpp
@@ -259,8 +259,15 @@ public:
     if (!I.getType()->isVoidTy() && !I.getName().empty()) {
       auto DILV = Builder.createAutoVariable(Scope, I.getName(), FileNode, Line,
                                              getOrCreateType(I.getType()));
-      Builder.insertDeclare(&I, DILV, Builder.createExpression(), NewLoc.get(),
-                            I.getParent());
+      if (isa<PHINode>(I))
+        Builder.insertDbgValueIntrinsic(&I, DILV, Builder.createExpression(),
+                                        NewLoc.get(), I.getParent()->getFirstNonPHI());
+      else if (Instruction *NI = I.getNextNonDebugInstruction(/* SkipPseudoOp */ true))
+        Builder.insertDbgValueIntrinsic(&I, DILV, Builder.createExpression(),
+                                        NewLoc.get(), NI);
+      else
+        Builder.insertDbgValueIntrinsic(&I, DILV, Builder.createExpression(),
+                                        NewLoc.get(), I.getParent());
     }
   }
 


### PR DESCRIPTION
Technically these are not addresses in memory, so it's important to use `dbg.value` instead of `dbg.declare`

Also insert the debug instrinsic just after the instruction that defines it.

Without this change, almost none of the local SSA values are available in gdb (it might be just the arguments that are) but with it I can very often print the arguments of the instruction execution is halted on:
![image](https://github.com/user-attachments/assets/3e458d8d-bea2-4fc2-af51-452330fb6401)