### PR TITLE
Replace 'File' in existing DISubprogram entries

### DIFF
--- a/DebugIR.cpp
+++ b/DebugIR.cpp
@@ -305,6 +305,7 @@ private:
 
     for (DISubprogram *S : Finder.subprograms()) {
       S->replaceUnit(CU);
+      S->replaceOperandWith(0, FileNode); // replace 'File'
     }
   }
 


### PR DESCRIPTION
I'm less certain about this change than #22 because LLVM doesn't seem to provide a 'nice' API to do this kind of replacement, but it seems to work just fine in my testing and without it `gdb` shows me the old source filename for many functions.